### PR TITLE
Changed which file main in package.json points to to the correct file…

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react",
     "prerender"
   ],
-  "main": "lib/index.js",
+  "main": "lib/render-react.js",
   "files": [
     "lib"
   ],


### PR DESCRIPTION
… so that this module may actually be required.

Without this `require('gulp-react-render')` errors out with `Error: Cannot find module 'gulp-render-react'`.
